### PR TITLE
acquire MAPBOX_ACCESS_TOKEN from env

### DIFF
--- a/src/config/mbToken.js
+++ b/src/config/mbToken.js
@@ -5,4 +5,4 @@
  * @category Configuration
  * @type {string}
  */
-export const MAPBOX_ACCESS_TOKEN = `${process.env.MAPBOX_ACCESS_TOKEN}`;
+export const MAPBOX_ACCESS_TOKEN = `${process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}`;


### PR DESCRIPTION
Seems like this is all that's needed in the codebase, and then we'll set the variable in Netlify.