### PR TITLE
Clustering of story markers

### DIFF
--- a/src/CustomLayers/icon-cluster-layer.js
+++ b/src/CustomLayers/icon-cluster-layer.js
@@ -21,7 +21,7 @@ function getIconName(size) {
 }
 
 function getIconSize(size) {
-  return Math.min(100, size) / 100 + 1;
+  return Math.min(100, size) / 100 + 1.5;
 }
 
 export default class IconClusterLayer extends CompositeLayer {

--- a/src/components/Map/MapSection.jsx
+++ b/src/components/Map/MapSection.jsx
@@ -694,7 +694,7 @@ function MapSection({
             pickable: true,
             getPosition: (d) => d.centroid,
             onClick: handleStoryClick,
-            sizeScale: 60,
+            sizeScale: 20,
             activeId: selectedStory?.id,
         }),
         cartogramText: new TextLayer({


### PR DESCRIPTION
Fixes #61 . The story markers now combine less aggressively i.e. the radius for a group of markers to be clustered has been reduced. Also, the actual size of the markers has been reduced in proportion. @Makosak Is this size of markers right?